### PR TITLE
added support for other promise libraries

### DIFF
--- a/lib/freeport.js
+++ b/lib/freeport.js
@@ -1,7 +1,8 @@
 var net = require('net')
 
-module.exports = () => {
-  return new Promise((resolve, reject) => {
+module.exports = (PromiseLibrary) => {
+  PromiseLibrary = PromiseLibrary || Promise
+  return new PromiseLibrary((resolve, reject) => {
     var server = net.createServer()
     var port = 0
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/achingbrain/freeport-promise"
   },
   "scripts": {
-    "test": "NODE_ENV=test; mocha",
+    "test": "NODE_ENV=test mocha",
     "test:coverage": "istanbul --include-all-sources cover _mocha",
     "test:coverage:check": "istanbul --include-all-sources cover _mocha && istanbul check-coverage --statement 100 --branch 100 --function 100",
     "lint": "standard",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/achingbrain/freeport-promise"
   },
   "scripts": {
-    "test": "NODE_ENV=test mocha",
+    "test": "NODE_ENV=test; mocha",
     "test:coverage": "istanbul --include-all-sources cover _mocha",
     "test:coverage:check": "istanbul --include-all-sources cover _mocha && istanbul check-coverage --statement 100 --branch 100 --function 100",
     "lint": "standard",
@@ -18,6 +18,7 @@
   },
   "license": "ISC",
   "devDependencies": {
+    "bluebird": "^3.4.6",
     "chai": "^3.0.0",
     "coveralls": "^2.11.4",
     "istanbul": "^0.4.0",

--- a/test/freeport.js
+++ b/test/freeport.js
@@ -11,4 +11,12 @@ describe('freeport', () => {
       expect(port).to.not.equal(0)
     })
   })
+  it('should work with a external promise library', () => {
+    var bluebird = require('bluebird')
+    return freeport(bluebird)
+    .then((port) => {
+      expect(port).to.be.a('number')
+      expect(port).to.not.equal(0)
+    })
+  })
 })


### PR DESCRIPTION
Hi! 

I really love your library! I use it every day. But always have to wrap it because I need some functions from the bluebird library which is a kind of superset of the standard Promise implementation.

With my change its possible (not necessary) to inject any promise library. I hope you will like it and it will be added to your project.

Greetings from Hamburg, Germany
Oliver